### PR TITLE
Depend on module 'spin' instead of file 'spin.js'

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ application's `package.json` or `bower.json` file.
 
 ## Usage
 
+If using require.js, ensure that [spin.js](http://fgnass.github.io/spin.js/)) is
+available as the module 'spin'.
+
+    require.config({
+        // ...
+        paths: {
+            // ...
+            'spin': 'path/to/spin.js'
+        }
+    });
+
 Wrap the Loader component around your loading content within your React
 component's `render` function.
 

--- a/lib/react-loader.js
+++ b/lib/react-loader.js
@@ -3,9 +3,9 @@
 (function (root, factory) {
 
   if (typeof define === 'function' && define.amd) {
-    define(['react', 'spin.js'], factory);
+    define(['react', 'spin'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    module.exports = factory(require('react'), require('spin.js'));
+    module.exports = factory(require('react'), require('spin'));
   } else {
     root.Loader = factory(root.React, root.Spinner);
   }

--- a/lib/react-loader.jsx
+++ b/lib/react-loader.jsx
@@ -3,9 +3,9 @@
 (function (root, factory) {
 
   if (typeof define === 'function' && define.amd) {
-    define(['react', 'spin.js'], factory);
+    define(['react', 'spin'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    module.exports = factory(require('react'), require('spin.js'));
+    module.exports = factory(require('react'), require('spin'));
   } else {
     root.Loader = factory(root.React, root.Spinner);
   }


### PR DESCRIPTION
This allows the location of spin.js to be defined by a path rather than relying spin.js to be in a particular location. This is particularly helpful for r.js optimization when the root path may be different than when loading in a browser.