### PR TITLE
Remove deprecated pragma

### DIFF
--- a/lib/react-loader.js
+++ b/lib/react-loader.js
@@ -1,5 +1,3 @@
-/** @jsx React.DOM */
-
 (function (root, factory) {
 
   if (typeof define === 'function' && define.amd) {

--- a/lib/react-loader.jsx
+++ b/lib/react-loader.jsx
@@ -1,5 +1,3 @@
-/** @jsx React.DOM */
-
 (function (root, factory) {
 
   if (typeof define === 'function' && define.amd) {


### PR DESCRIPTION
When bundling react-loader using Babel, a deprecation error appears: `The @jsx React.DOM pragma has been deprecated as of React 0.12`. This PR removes the pragma and I can keep using your useful component.

http://facebook.github.io/react/blog/2014/10/16/react-v0.12-rc1.html#the-jsx-pragma-is-gone