### PR TITLE
Support `scale` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ available to spin.js are available to this component in two ways.
         <Loader loaded={false} lines={13} length={20} width={10} radius={30}
                 corners={1} rotate={0} direction={1} color="#000" speed={1}
                 trail={60} shadow={false} hwaccel={false} className="spinner"
-                zIndex={2e9} top="50%" left="50%" />
+                zIndex={2e9} top="50%" left="50%" scale={1.00} />
 
 2. Alternatively, you can use supply an object using the `options` key:
 
@@ -92,7 +92,8 @@ available to spin.js are available to this component in two ways.
             hwaccel: false,
             zIndex: 2e9,
             top: '50%',
-            left: '50%'
+            left: '50%',
+            scale: 1.00
         };
 
         <Loader loaded={false} options={options} className="spinner" />

--- a/lib/react-loader.js
+++ b/lib/react-loader.js
@@ -15,6 +15,7 @@
       component: React.PropTypes.any,
       loaded:    React.PropTypes.bool,
       options:   React.PropTypes.object,
+      scale:     React.PropTypes.number,
       lines:     React.PropTypes.number,
       length:    React.PropTypes.number,
       width:     React.PropTypes.number,

--- a/lib/react-loader.jsx
+++ b/lib/react-loader.jsx
@@ -15,6 +15,7 @@
       component: React.PropTypes.any,
       loaded:    React.PropTypes.bool,
       options:   React.PropTypes.object,
+      scale:     React.PropTypes.number,
       lines:     React.PropTypes.number,
       length:    React.PropTypes.number,
       width:     React.PropTypes.number,


### PR DESCRIPTION
Didn't add a test for this as there are no other tests for specific properties. I did, however, run the tests to confirm there were no regressions.

```
  Loader
    loading is in progress
      ✓ renders the correct output
    loading is in progress with component option
      ✓ renders the correct output
    loading is in progress with spinner options
      ✓ renders the correct output
    loading is in progress with spinner options and options object is used instead of props
      ✓ renders the correct output
    loading is complete
      ✓ renders the correct output
    loading is complete with component option
      ✓ renders the correct output


  6 passing (18ms)
```