### PR TITLE
Added compatibility with React 0.14

### DIFF
--- a/lib/react-loader.js
+++ b/lib/react-loader.js
@@ -81,7 +81,10 @@
     spin: function () {
       if (this.isMounted() && !this.state.loaded) {
         var spinner = new Spinner(this.state.options);
-        var target = this.refs.loader.getDOMNode();
+        var target = this.refs.loader;
+        if (!target.nodeType) {
+          target = target.getDOMNode();
+        }
 
         // clear out any other spinners from previous renders
         target.innerHTML = '';

--- a/lib/react-loader.js
+++ b/lib/react-loader.js
@@ -1,14 +1,14 @@
 (function (root, factory) {
 
   if (typeof define === 'function' && define.amd) {
-    define(['react', 'spin.js'], factory);
+    define(['react', 'react-dom', 'spin.js'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    module.exports = factory(require('react'), require('spin.js'));
+    module.exports = factory(require('react'), require('react-dom'), require('spin.js'));
   } else {
-    root.Loader = factory(root.React, root.Spinner);
+    root.Loader = factory(root.React, root.ReactDOM, root.Spinner);
   }
 
-}(this, function (React, Spinner) {
+}(this, function (React, ReactDOM, Spinner) {
 
   var Loader = React.createClass({displayName: "Loader",
     propTypes: {
@@ -81,10 +81,7 @@
     spin: function () {
       if (this.isMounted() && !this.state.loaded) {
         var spinner = new Spinner(this.state.options);
-        var target = this.refs.loader;
-        if (!target.nodeType) {
-          target = target.getDOMNode();
-        }
+        var target =  ReactDOM.findDOMNode(this.refs.loader);
 
         // clear out any other spinners from previous renders
         target.innerHTML = '';

--- a/lib/react-loader.jsx
+++ b/lib/react-loader.jsx
@@ -81,7 +81,10 @@
     spin: function () {
       if (this.isMounted() && !this.state.loaded) {
         var spinner = new Spinner(this.state.options);
-        var target = this.refs.loader.getDOMNode();
+        var target = this.refs.loader;
+        if (!target.nodeType) {
+          target = target.getDOMNode();
+        }
 
         // clear out any other spinners from previous renders
         target.innerHTML = '';

--- a/lib/react-loader.jsx
+++ b/lib/react-loader.jsx
@@ -1,14 +1,14 @@
 (function (root, factory) {
 
   if (typeof define === 'function' && define.amd) {
-    define(['react', 'spin.js'], factory);
+    define(['react', 'react-dom', 'spin.js'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    module.exports = factory(require('react'), require('spin.js'));
+    module.exports = factory(require('react'), require('react-dom'), require('spin.js'));
   } else {
-    root.Loader = factory(root.React, root.Spinner);
+    root.Loader = factory(root.React, root.ReactDOM, root.Spinner);
   }
 
-}(this, function (React, Spinner) {
+}(this, function (React, ReactDOM, Spinner) {
 
   var Loader = React.createClass({
     propTypes: {
@@ -81,10 +81,7 @@
     spin: function () {
       if (this.isMounted() && !this.state.loaded) {
         var spinner = new Spinner(this.state.options);
-        var target = this.refs.loader;
-        if (!target.nodeType) {
-          target = target.getDOMNode();
-        }
+        var target =  ReactDOM.findDOMNode(this.refs.loader);
 
         // clear out any other spinners from previous renders
         target.innerHTML = '';

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
   },
   "homepage": "https://github.com/quickleft/react-loader",
   "dependencies": {
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0",
     "spin.js": "2.x"
   },
   "devDependencies": {

--- a/test/spec/react-loader-test.js
+++ b/test/spec/react-loader-test.js
@@ -42,13 +42,20 @@ describe('Loader', function () {
 
   testCases.forEach(function (testCase) {
     describe(testCase.description, function () {
+      var container;
       beforeEach(function () {
         var loader = React.createElement(Loader, testCase.props, 'Welcome');
-        React.render(loader, document.body);
+        container = document.createElement('div');
+        document.body.appendChild(container);
+        React.render(loader, container);
+      });
+
+      afterEach(function () {
+        document.body.removeChild(container);
       });
 
       it('renders the correct output', function () {
-        expect(document.body.innerHTML).to.match(testCase.expectedOutput);
+        expect(container.innerHTML).to.match(testCase.expectedOutput);
       })
     });
   });


### PR DESCRIPTION
In React 0.14, refs to a DOM node will return the node itself. Calling
getDOMNode() on it works, but throws a loud warning. See the [announcement blog post](https://facebook.github.io/react/blog/2015/07/03/react-v0.14-beta-1.html#dom-node-refs)