### PR TITLE
Bump version to 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ component a simple mechanism for rendering a loading spinner (via
 [spin.js](http://fgnass.github.io/spin.js/)) while data is loading, such as an
 asynchronous request to load data for a view.
 
+> Important Note: The 2.x branch is compatible with React 1.4 and higher. If
+> you're working with an older version of React, please use the 1.x branch.
+
 ## Installation
 
 react-loader is available through both [Bower](http://bower.io/) and

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "react-loader",
   "description": "React component that displays a spinner via spin.js until your component is loaded",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "main": "lib/react-loader.js",
   "keywords": [
     "react",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-loader",
   "description": "React component that displays a spinner via spin.js until your component is loaded",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "main": "lib/react-loader.js",
   "scripts": {
     "build": "./node_modules/.bin/jsx -x jsx lib lib",


### PR DESCRIPTION
#### What's this PR do?

Bumps the package version on Bower and npm to `2.0.0`. The reason for major version change is that compatibility with React `0.14` introduces a breaking change that is not compatible with React `0.13` or earlier.

#### Where should the reviewer start?

Tiny changes. Updated the version number in `package.json` and `bower.json` and added a note to the read me for users of earlier versions of React.