### PR TITLE
use className in props when provided

### DIFF
--- a/lib/react-loader.js
+++ b/lib/react-loader.js
@@ -96,7 +96,7 @@
         props = { key: 'content', className: 'loadedContent' };
         children = this.props.children;
       } else {
-        props = { key: 'loader', ref: 'loader', className: 'loader' };
+        props = { key: 'loader', ref: 'loader', className: this.props.className || 'loader' };
       }
 
       return React.createElement(this.props.component, props, children);

--- a/lib/react-loader.jsx
+++ b/lib/react-loader.jsx
@@ -96,7 +96,7 @@
         props = { key: 'content', className: 'loadedContent' };
         children = this.props.children;
       } else {
-        props = { key: 'loader', ref: 'loader', className: 'loader' };
+        props = { key: 'loader', ref: 'loader', className: this.props.className || 'loader' };
       }
 
       return React.createElement(this.props.component, props, children);

--- a/test/spec/react-loader-test.js
+++ b/test/spec/react-loader-test.js
@@ -38,7 +38,15 @@ describe('Loader', function () {
     description: 'loading is complete with component option',
     props: { loaded: true, component: 'span' },
     expectedOutput: /<span class="loadedContent"[^>]*?>Welcome<\/span>/
-  }];
+  },
+  {
+    description: 'loading is in progress with custom className',
+    props: {
+      loaded: false,
+      className: 'my-loader-class'
+    },
+    expectedOutput: /<div class="my-loader-class"[^>]*?><div class="spinner"/
+  },];
 
   testCases.forEach(function (testCase) {
     describe(testCase.description, function () {


### PR DESCRIPTION
Although `className` is included as part of the Loader `props` it was not used as `class` for the `loaded = false` condition.
I need to provide my own class for the component and I would like to have this merged.

I wrote a simple small test, but I was not able to run the test infrastructure. I found some dependencies issues while I tried to do that. I tried to update the libraries as well but it doesn't make the situation any better.

I was also wondering whether would be possible to have travisCI integration for this project.

refers to #19 