### PR TITLE
Custom class definition

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,13 @@
+#### What does this PR do?
+
+#### Where should the reviewer start?
+
+#### How should this be manually tested?
+
+#### Any background context you want to provide?
+
+#### What are the relevant issues (if any)?
+
+#### Screenshots (if appropriate)
+
+#### Obligatory GIF

--- a/lib/react-loader.js
+++ b/lib/react-loader.js
@@ -12,31 +12,36 @@
 
   var Loader = React.createClass({displayName: "Loader",
     propTypes: {
-      component:       React.PropTypes.any,
-      loaded:          React.PropTypes.bool,
-      options:         React.PropTypes.object,
-      scale:           React.PropTypes.number,
-      lines:           React.PropTypes.number,
-      length:          React.PropTypes.number,
-      width:           React.PropTypes.number,
-      radius:          React.PropTypes.number,
-      corners:         React.PropTypes.number,
-      rotate:          React.PropTypes.number,
-      direction:       React.PropTypes.oneOf([1, -1]),
-      color:           React.PropTypes.string,
-      speed:           React.PropTypes.number,
-      trail:           React.PropTypes.number,
-      shadow:          React.PropTypes.bool,
-      hwaccell:        React.PropTypes.bool,
       className:       React.PropTypes.string,
-      zIndex:          React.PropTypes.number,
-      top:             React.PropTypes.string,
+      color:           React.PropTypes.string,
+      component:       React.PropTypes.any,
+      corners:         React.PropTypes.number,
+      direction:       React.PropTypes.oneOf([1, -1]),
+      hwaccell:        React.PropTypes.bool,
       left:            React.PropTypes.string,
-      loadedClassName: React.PropTypes.string
+      length:          React.PropTypes.number,
+      lines:           React.PropTypes.number,
+      loaded:          React.PropTypes.bool,
+      loadedClassName: React.PropTypes.string,
+      options:         React.PropTypes.object,
+      parentClassName: React.PropTypes.string,
+      radius:          React.PropTypes.number,
+      rotate:          React.PropTypes.number,
+      scale:           React.PropTypes.number,
+      shadow:          React.PropTypes.bool,
+      speed:           React.PropTypes.number,
+      top:             React.PropTypes.string,
+      trail:           React.PropTypes.number,
+      width:           React.PropTypes.number,
+      zIndex:          React.PropTypes.number
     },
 
     getDefaultProps: function () {
-      return { component: 'div', loadedClassName: 'loadedContent' };
+      return {
+        component: 'div',
+        loadedClassName: 'loadedContent',
+        parentClassName: 'loader'
+      };
     },
 
     getInitialState: function () {
@@ -97,7 +102,7 @@
         props = { key: 'content', className: this.props.loadedClassName };
         children = this.props.children;
       } else {
-        props = { key: 'loader', ref: 'loader', className: 'loader' };
+        props = { key: 'loader', ref: 'loader', className: this.props.parentClassName };
       }
 
       return React.createElement(this.props.component, props, children);

--- a/lib/react-loader.jsx
+++ b/lib/react-loader.jsx
@@ -12,31 +12,36 @@
 
   var Loader = React.createClass({
     propTypes: {
-      component:       React.PropTypes.any,
-      loaded:          React.PropTypes.bool,
-      options:         React.PropTypes.object,
-      scale:           React.PropTypes.number,
-      lines:           React.PropTypes.number,
-      length:          React.PropTypes.number,
-      width:           React.PropTypes.number,
-      radius:          React.PropTypes.number,
-      corners:         React.PropTypes.number,
-      rotate:          React.PropTypes.number,
-      direction:       React.PropTypes.oneOf([1, -1]),
-      color:           React.PropTypes.string,
-      speed:           React.PropTypes.number,
-      trail:           React.PropTypes.number,
-      shadow:          React.PropTypes.bool,
-      hwaccell:        React.PropTypes.bool,
       className:       React.PropTypes.string,
-      zIndex:          React.PropTypes.number,
-      top:             React.PropTypes.string,
+      color:           React.PropTypes.string,
+      component:       React.PropTypes.any,
+      corners:         React.PropTypes.number,
+      direction:       React.PropTypes.oneOf([1, -1]),
+      hwaccell:        React.PropTypes.bool,
       left:            React.PropTypes.string,
-      loadedClassName: React.PropTypes.string
+      length:          React.PropTypes.number,
+      lines:           React.PropTypes.number,
+      loaded:          React.PropTypes.bool,
+      loadedClassName: React.PropTypes.string,
+      options:         React.PropTypes.object,
+      parentClassName: React.PropTypes.string,
+      radius:          React.PropTypes.number,
+      rotate:          React.PropTypes.number,
+      scale:           React.PropTypes.number,
+      shadow:          React.PropTypes.bool,
+      speed:           React.PropTypes.number,
+      top:             React.PropTypes.string,
+      trail:           React.PropTypes.number,
+      width:           React.PropTypes.number,
+      zIndex:          React.PropTypes.number
     },
 
     getDefaultProps: function () {
-      return { component: 'div', loadedClassName: 'loadedContent' };
+      return {
+        component: 'div',
+        loadedClassName: 'loadedContent',
+        parentClassName: 'loader'
+      };
     },
 
     getInitialState: function () {
@@ -97,7 +102,7 @@
         props = { key: 'content', className: this.props.loadedClassName };
         children = this.props.children;
       } else {
-        props = { key: 'loader', ref: 'loader', className: 'loader' };
+        props = { key: 'loader', ref: 'loader', className: this.props.parentClassName };
       }
 
       return React.createElement(this.props.component, props, children);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-loader",
   "description": "React component that displays a spinner via spin.js until your component is loaded",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "main": "lib/react-loader.js",
   "scripts": {
     "build": "./node_modules/.bin/jsx -x jsx lib lib",

--- a/test/spec/react-loader-test.js
+++ b/test/spec/react-loader-test.js
@@ -16,6 +16,16 @@ describe('Loader', function () {
     expectedOutput: /<span class="loader"[^>]*?><div class="spinner"/
   },
   {
+    description: 'loading is in progress with custom className on the loader component',
+    props: { loaded: false, parentClassName: 'my-loader-class' },
+    expectedOutput: /<div class="my-loader-class"[^>]*?><div class="spinner"/
+  },
+  {
+    description: 'loading is in progress with custom className on the spinner component',
+    props: { loaded: false, className: 'my-spinner-class' },
+    expectedOutput: /<div class="loader"[^>]*?><div class="my-spinner-class"/
+  },
+  {
     description: 'loading is in progress with spinner options',
     props: { loaded: false, radius: 17, width: 900 },
     expectedOutput: /<div class="loader"[^>]*?><div class="spinner"[^>]*?>.*translate\(17px, 0px\).*style="[^"]*?height: 900px;/


### PR DESCRIPTION
#### What does this PR do?
1. Custom class names can be supplied to both the 'spinner' and its parent 'loader' elements.
2. Adds a PR template to the repo so it will be auto-generated for future PRs.
3. Alphabetizes the list of propTypes.

#### Where should the reviewer start?
Relevant changes in `lib/react-loader.jsx`.

#### How should this be manually tested?
Tests have been added for this functionality.
Run the tests with `npm run test`.

#### Any background context you want to provide?
Thank you to @fabriziomoscon for contributing [PR 32](https://github.com/quickleft/react-loader/pull/32).

#### What are the relevant issues (if any)?
refs [#19](https://github.com/quickleft/react-loader/issues/19)

#### Screenshots (if appropriate)
n/a

#### Obligatory GIF
![](http://i.giphy.com/oTYNjGUJGvU0o.gif)