### PR TITLE
Support server-side rendering

### DIFF
--- a/lib/react-loader.js
+++ b/lib/react-loader.js
@@ -1,14 +1,14 @@
 (function (root, factory) {
 
   if (typeof define === 'function' && define.amd) {
-    define(['react', 'react-dom', 'spin.js'], factory);
+    define(['react', 'react-dom', 'spin.js', 'exenv'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    module.exports = factory(require('react'), require('react-dom'), require('spin.js'));
+    module.exports = factory(require('react'), require('react-dom'), require('spin.js'), require('exenv'));
   } else {
-    root.Loader = factory(root.React, root.ReactDOM, root.Spinner);
+    root.Loader = factory(root.React, root.ReactDOM, root.Spinner, root.ExecutionEnvironment);
   }
 
-}(this, function (React, ReactDOM, Spinner) {
+}(this, function (React, ReactDOM, Spinner, ExecutionEnvironment) {
 
   var Loader = React.createClass({displayName: "Loader",
     propTypes: {
@@ -85,7 +85,7 @@
     },
 
     spin: function () {
-      if (this.isMounted() && !this.state.loaded) {
+      if (ExecutionEnvironment.canUseDOM && this.isMounted() && !this.state.loaded) {
         var spinner = new Spinner(this.state.options);
         var target =  ReactDOM.findDOMNode(this.refs.loader);
 

--- a/lib/react-loader.jsx
+++ b/lib/react-loader.jsx
@@ -1,14 +1,14 @@
 (function (root, factory) {
 
   if (typeof define === 'function' && define.amd) {
-    define(['react', 'react-dom', 'spin.js'], factory);
+    define(['react', 'react-dom', 'spin.js', 'exenv'], factory);
   } else if (typeof module === 'object' && typeof module.exports === 'object') {
-    module.exports = factory(require('react'), require('react-dom'), require('spin.js'));
+    module.exports = factory(require('react'), require('react-dom'), require('spin.js'), require('exenv'));
   } else {
-    root.Loader = factory(root.React, root.ReactDOM, root.Spinner);
+    root.Loader = factory(root.React, root.ReactDOM, root.Spinner, root.ExecutionEnvironment);
   }
 
-}(this, function (React, ReactDOM, Spinner) {
+}(this, function (React, ReactDOM, Spinner, ExecutionEnvironment) {
 
   var Loader = React.createClass({
     propTypes: {
@@ -85,7 +85,7 @@
     },
 
     spin: function () {
-      if (this.isMounted() && !this.state.loaded) {
+      if (ExecutionEnvironment.canUseDOM && this.isMounted() && !this.state.loaded) {
         var spinner = new Spinner(this.state.options);
         var target =  ReactDOM.findDOMNode(this.refs.loader);
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "homepage": "https://github.com/quickleft/react-loader",
   "dependencies": {
+    "exenv": "^1.2.0",
     "react": "^0.14.0",
     "react-dom": "^0.14.0",
     "spin.js": "2.x"


### PR DESCRIPTION
#### What does this PR do?
This PR allows `react-loader` to play nice with server-side rendering by checking if a DOM is available before animating the spinner.

#### How should this be manually tested?
`npm test`, all tests should pass

#### Any background context you want to provide?
Rendering the spinner on the server is useful to avoid a flash of content between server/client.

#### What are the relevant issues (if any)?
Should solve #16 
