### PR TITLE
Add support for react 15.0, move react to peerDenpendencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,18 +33,22 @@
     "url": "https://github.com/quickleft/react-loader/issues"
   },
   "homepage": "https://github.com/quickleft/react-loader",
+  "peerDependencies": {
+    "react": "^0.14.0 || ^15.0.0",
+    "react-dom": "^0.14.0 || ^15.0.0"
+  },
   "dependencies": {
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0",
     "spin.js": "2.x"
   },
   "devDependencies": {
     "browserify": "^5.9.1",
     "chai": "^1.9.1",
     "es5-shim": "^4.0.1",
-    "mocha-phantomjs": "^3.5.0",
-    "react": "^0.12.2",
-    "react-tools": "^0.12.2",
-    "reactify": "^0.14.0"
+    "mocha": "^2.4.5",
+    "mocha-phantomjs": "^4.0.2",
+    "react": "^15.0.0",
+    "react-dom": "^15.0.0",
+    "react-tools": "^0.13.3",
+    "reactify": "^1.1.1"
   }
 }

--- a/test/index.html
+++ b/test/index.html
@@ -2,9 +2,9 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <link rel="stylesheet" type="text/css" href="../node_modules/mocha-phantomjs/node_modules/mocha/mocha.css" />
+    <link rel="stylesheet" type="text/css" href="../node_modules/mocha/mocha.css" />
     <script src="../node_modules/es5-shim/es5-shim.js"></script>
-    <script src="../node_modules/mocha-phantomjs/node_modules/mocha/mocha.js"></script>
+    <script src="../node_modules/mocha/mocha.js"></script>
     <script>
       mocha.ui('bdd');
       mocha.reporter('html');

--- a/test/spec/react-loader-test.js
+++ b/test/spec/react-loader-test.js
@@ -1,6 +1,7 @@
 /** @jsx React.DOM */
 
 var React = require('react');
+var ReactDOM = require('react-dom');
 var Loader = require('../../lib/react-loader');
 var expect = require('chai').expect;
 
@@ -8,27 +9,27 @@ describe('Loader', function () {
   var testCases = [{
     description: 'loading is in progress',
     props: { loaded: false },
-    expectedOutput: /<div class="loader"[^>]*?><div class="spinner"/
+    expectedOutput: /<div [^>]*?class="loader"[^>]*?><div [^>]*?class="spinner"/
   },
   {
     description: 'loading is in progress with component option',
     props: { loaded: false, component: 'span' },
-    expectedOutput: /<span class="loader"[^>]*?><div class="spinner"/
+    expectedOutput: /<span [^>]*?class="loader"[^>]*?><div [^>]*?class="spinner"/
   },
   {
     description: 'loading is in progress with custom className on the loader component',
     props: { loaded: false, parentClassName: 'my-loader-class' },
-    expectedOutput: /<div class="my-loader-class"[^>]*?><div class="spinner"/
+    expectedOutput: /<div [^>]*?class="my-loader-class"[^>]*?><div [^>]*?class="spinner"/
   },
   {
     description: 'loading is in progress with custom className on the spinner component',
     props: { loaded: false, className: 'my-spinner-class' },
-    expectedOutput: /<div class="loader"[^>]*?><div class="my-spinner-class"/
+    expectedOutput: /<div [^>]*?class="loader"[^>]*?><div [^>]*?class="my-spinner-class"/
   },
   {
     description: 'loading is in progress with spinner options',
     props: { loaded: false, radius: 17, width: 900 },
-    expectedOutput: /<div class="loader"[^>]*?><div class="spinner"[^>]*?>.*translate\(17px, 0px\).*style="[^"]*?height: 900px;/
+    expectedOutput: /<div [^>]*?class="loader"[^>]*?><div [^>]*?class="spinner"[^>]*?>.*translate\(17px, 0px\).*style="[^"]*?height: 900px;/
   },
   {
     description: 'loading is in progress with spinner options and options object is used instead of props',
@@ -37,22 +38,22 @@ describe('Loader', function () {
         width: 900,
         options: { width: 200 }
     },
-    expectedOutput: /<div class="loader"[^>]*?><div class="spinner"[^>]*?>.*style="[^"]*?height: 200px;/
+    expectedOutput: /<div [^>]*?class="loader"[^>]*?><div [^>]*?class="spinner"[^>]*?>.*style="[^"]*?height: 200px;/
   },
   {
     description: 'loading is complete',
     props: { loaded: true },
-    expectedOutput: /<div class="loadedContent"[^>]*>Welcome<\/div>/
+    expectedOutput: /<div [^>]*?class="loadedContent"[^>]*>Welcome<\/div>/
   },
   {
     description: 'loading is complete with component option',
     props: { loaded: true, component: 'span' },
-    expectedOutput: /<span class="loadedContent"[^>]*?>Welcome<\/span>/
+    expectedOutput: /<span [^>]*?class="loadedContent"[^>]*?>Welcome<\/span>/
   },
   {
     description: 'a custom className can be passed to the loaded content',
     props: { loaded: true, loadedClassName: 'my-class' },
-    expectedOutput: /<div class="my-class"[^>]*?>Welcome<\/div>/
+    expectedOutput: /<div [^>]*?class="my-class"[^>]*?>Welcome<\/div>/
   }];
 
   testCases.forEach(function (testCase) {
@@ -62,7 +63,7 @@ describe('Loader', function () {
         var loader = React.createElement(Loader, testCase.props, 'Welcome');
         container = document.createElement('div');
         document.body.appendChild(container);
-        React.render(loader, container);
+        ReactDOM.render(loader, container);
       });
 
       afterEach(function () {


### PR DESCRIPTION
This PR fixes https://github.com/quickleft/react-loader/issues/39.

It moves `react` and `react-dom` from `dependencies` to `peerDependencies`. It also allows `react` `15.0` versions to be used.

I also updated the `devDependencies` to work with `react` `15.0`. I had to upgrade some of the testing libraries as it wouldn't pass the specs until I did.

The reason specs were failing against `react` `15.0` were because it adds a new `data-reactroot` attribute, and your regex expectations were not expecting this new attribute to come before the `class` attribute. 